### PR TITLE
Update install.yml

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -49,6 +49,7 @@
     name: "{{ prometheus_blackbox_exporter_container_network }}"
     driver: bridge
     driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
+  when: prometheus_blackbox_exporter_container_network != 'host'
 
 - name: Ensure prometheus-blackbox-exporter systemd service is present
   ansible.builtin.template:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -5,17 +5,6 @@
 
 ---
 
-- name: Ensure prometheus-blackbox-exporter image is pulled
-  community.docker.docker_image:
-    name: "{{ prometheus_blackbox_exporter_container_image }}"
-    source: "{{ 'pull' if ansible_version.major > 2 or ansible_version.minor > 7 else omit }}"
-    force_source: "{{ prometheus_blackbox_exporter_container_image_force_pull if ansible_version.major > 2 or ansible_version.minor >= 8 else omit }}"
-    force: "{{ omit if ansible_version.major > 2 or ansible_version.minor >= 8 else prometheus_blackbox_exporter_container_image_force_pull }}"
-  register: result
-  retries: "{{ devture_playbook_help_container_retries_count }}"
-  delay: "{{ devture_playbook_help_container_retries_delay }}"
-  until: result is not failed
-
 - name: Ensure prometheus-blackbox-exporter paths exist
   ansible.builtin.file:
     path: "{{ item }}"
@@ -27,7 +16,7 @@
     - "{{ prometheus_blackbox_exporter_base_path }}"
     - "{{ prometheus_blackbox_exporter_config_path }}"
 
-- name: Ensure prometheus-blackbox-exporter labels file is created
+- name: Ensure prometheus-blackbox-exporter labels file installed
   ansible.builtin.template:
     src: "{{ role_path }}/templates/labels.j2"
     dest: "{{ prometheus_blackbox_exporter_config_path }}/labels"
@@ -43,6 +32,17 @@
     group: "{{ prometheus_blackbox_exporter_gid }}"
     mode: 0640
 
+- name: Ensure prometheus-blackbox-exporter image is pulled
+  community.docker.docker_image:
+    name: "{{ prometheus_blackbox_exporter_container_image }}"
+    source: "{{ 'pull' if ansible_version.major > 2 or ansible_version.minor > 7 else omit }}"
+    force_source: "{{ prometheus_blackbox_exporter_container_image_force_pull if ansible_version.major > 2 or ansible_version.minor >= 8 else omit }}"
+    force: "{{ omit if ansible_version.major > 2 or ansible_version.minor >= 8 else prometheus_blackbox_exporter_container_image_force_pull }}"
+  register: result
+  retries: "{{ devture_playbook_help_container_retries_count }}"
+  delay: "{{ devture_playbook_help_container_retries_delay }}"
+  until: result is not failed
+
 - name: Ensure prometheus-blackbox-exporter container network is created
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
@@ -50,7 +50,7 @@
     driver: bridge
     driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
-- name: Ensure prometheus-blackbox-exporter systemd service installed
+- name: Ensure prometheus-blackbox-exporter systemd service is present
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/prometheus-blackbox-exporter.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/{{ prometheus_blackbox_exporter_identifier }}.service"


### PR DESCRIPTION
Adding ` when: prometheus_blackbox_exporter_container_network != 'host'` follows https://github.com/mother-of-all-self-hosting/ansible-role-prometheus-node-exporter/blob/ab8ae8a01f5b35b104c18ead4627097a6e4654f4/tasks/install.yml, as https://github.com/mother-of-all-self-hosting/ansible-role-prometheus-ssh-exporter/pull/5 does.