### PR TITLE
Add ICMP module to configuration

### DIFF
--- a/templates/config.yml.j2
+++ b/templates/config.yml.j2
@@ -23,3 +23,8 @@ modules:
   dns:
     prober: dns
     timeout: 5s
+  icmp:
+    prober: icmp
+    timeout: 5s
+    icmp:
+      preferred_ip_protocol: ip4


### PR DESCRIPTION
This PR adds the ICMP module to the blackbox exporter configuration file. Enabling workloads such as the following:

```yaml
prometheus_config_scrape_configs_additional:
  - job_name: router-blackbox
    metrics_path: /probe
    params:
      module: [icmp]
    relabel_configs:
      - source_labels: [__address__]
        target_label: __param_target
      - target_label: __address__
        replacement: blackbox-server-ip:blackbox-server-port
    static_configs:
      - targets:
          - 172.22.23.1
        labels:
          instance: remote-1
          job: blackbox-exporter

      - targets:
          - 172.22.22.1
        labels:
          instance: remote-2
          job: blackbox-exporter
```

Without the ICMP module this job gets a `HTTP 400 Bad Request` error.