### PR TITLE
Add 2 missing Traefik variables

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -75,6 +75,8 @@ prometheus_blackbox_exporter_container_labels_traefik_docker_network: "{{ promet
 prometheus_blackbox_exporter_container_labels_traefik_hostname: "{{ prometheus_blackbox_exporter_hostname }}"
 # The path prefix must either be `/` or not end with a slash (e.g. `/metrics`).
 prometheus_blackbox_exporter_container_labels_traefik_path_prefix: "{{ prometheus_blackbox_exporter_path_prefix }}"
+prometheus_blackbox_exporter_container_labels_traefik_rule: "Host(`{{ prometheus_blackbox_exporter_container_labels_traefik_hostname }}`){% if prometheus_blackbox_exporter_container_labels_traefik_path_prefix != '/' %} && PathPrefix(`{{ prometheus_blackbox_exporter_container_labels_traefik_path_prefix }}`){% endif %}"
+prometheus_blackbox_exporter_container_labels_traefik_priority: 0
 prometheus_blackbox_exporter_container_labels_traefik_entrypoints: web-secure
 prometheus_blackbox_exporter_container_labels_traefik_tls: "{{ prometheus_blackbox_exporter_container_labels_traefik_entrypoints != 'web' }}"
 prometheus_blackbox_exporter_container_labels_traefik_tls_certResolver: default  # noqa var-naming

--- a/templates/labels.j2
+++ b/templates/labels.j2
@@ -31,13 +31,13 @@ traefik.http.routers.{{ prometheus_blackbox_exporter_identifier }}.middlewares={
 {% endif %}
 
 traefik.http.routers.{{ prometheus_blackbox_exporter_identifier }}.service={{ prometheus_blackbox_exporter_identifier }}
+traefik.http.routers.{{ prometheus_blackbox_exporter_identifier }}.priority={{ prometheus_blackbox_exporter_container_labels_traefik_priority }}
+traefik.http.routers.{{ prometheus_blackbox_exporter_identifier }}.entrypoints={{ prometheus_blackbox_exporter_container_labels_traefik_entrypoints }}
 
 traefik.http.routers.{{ prometheus_blackbox_exporter_identifier }}.tls={{ prometheus_blackbox_exporter_container_labels_traefik_tls | to_json }}
 {% if prometheus_blackbox_exporter_container_labels_traefik_tls %}
 traefik.http.routers.{{ prometheus_blackbox_exporter_identifier }}.tls.certResolver={{ prometheus_blackbox_exporter_container_labels_traefik_tls_certResolver }}
 {% endif %}
-
-traefik.http.routers.{{ prometheus_blackbox_exporter_identifier }}.entrypoints={{ prometheus_blackbox_exporter_container_labels_traefik_entrypoints }}
 
 {% endif %}
 


### PR DESCRIPTION
Adds 2 missing Traefik variables:

1. `prometheus_blackbox_exporter_container_labels_traefik_rule`
2. `prometheus_blackbox_exporter_container_labels_traefik_priority`

Currently since `prometheus_blackbox_exporter_container_labels_traefik_rule` is used [here](https://github.com/mother-of-all-self-hosting/ansible-role-prometheus-blackbox-exporter/blob/4ed02d8d722544a648c33f94b9347d35b1f8255a/templates/labels.j2#L27) but not defined it is possible to run into and undefined variable error. 

![image](https://github.com/user-attachments/assets/5cdd80a9-74fe-4018-a506-1adc0f33eaea)
